### PR TITLE
Fix where emails weren't received from contact form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "butchers-market",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "private": true,
   "description": "Small description for butchers-market goes here",
   "repository": "",

--- a/public/server/feedback.php
+++ b/public/server/feedback.php
@@ -12,12 +12,12 @@ require_once "recaptcha/secret_key.php";
 $siteKey = "6LcrHAITAAAAACvTiT4qS4dvbwL7wgGRXhJtsKim";
 
 // Email address where the message should be delivered
-$emailTo = 'drew@thebutchersmarket.com';
+$emailTo = 'thebutchersmarket@gmail.com';
 
 // From email address, in case your server prohibits sending emails from addresses other than those of your
 // own domain (e.g. email@yourdomain.com). If this is used then all email messages from your contact form will appear
 // from this address instead of actual sender. */
-$from = '';
+$from = 'drew@thebutchersmarket.com';
 
 // This will be the subject of the contact form message
 $subject = 'Butcher Contact';


### PR DESCRIPTION
Drew noticed today that he wasn't receiving emails anymore from the contact form. After looking into it, the following changes were made:

1. The email address being sent to (drew@thebutchersmarket.com) was not receiving emails, so changed it to "thebutchersmarket@gmail.com".
2. In order to prevent the emails from going to the junk folder, it's being sent from an address on the domain (drew@thebutchersmarket.com).