### PR TITLE
Refactor file uploads and add PDF to package bundles

### DIFF
--- a/app/models/package-bundle.js
+++ b/app/models/package-bundle.js
@@ -1,9 +1,19 @@
 import Model, { attr } from '@ember-data/model';
+import config from 'butchers-market/config/environment';
 
 export default class PackageBundle extends Model {
   @attr('number') displayOrder;
   @attr('string') title;
-  @attr('string') flyerDownloadLink;
+  @attr('string') flyerDownloadLink; // deprecated!
+  @attr('string') fileUrl;
   @attr prices; // Array of strings
   @attr items; // Array of strings
+
+  get fileUrlPath() {
+    if (this.fileUrl) {
+      return `${config.uploadsDir}${this.fileUrl}`;
+    }
+
+    return null;
+  }
 }

--- a/app/pods/admin/deli-items/components/deli-item-form/component.js
+++ b/app/pods/admin/deli-items/components/deli-item-form/component.js
@@ -7,6 +7,7 @@ import lookupValidator from 'ember-changeset-validations';
 import DeliItemValidations from 'butchers-market/validations/deli-item';
 import { dropTask, enqueueTask } from 'ember-concurrency';
 import baseUrl from 'butchers-market/utils/base-url';
+import { generateFileName } from 'butchers-market/utils/file-name';
 
 export default class DeliItemFormComponent extends Component {
   @service router;
@@ -68,10 +69,12 @@ export default class DeliItemFormComponent extends Component {
 
     try {
       if (this.image) {
-        let response = yield this.image.upload(`${baseUrl}/upload`, {
+        const generatedFileName = generateFileName(this.image);
+        yield this.image.upload(`${baseUrl}/upload`, {
           headers: this.uploadHeaders,
+          data: { generatedFileName },
         });
-        this.changeset.set('imageUrl', response.body);
+        this.changeset.set('imageUrl', generatedFileName);
       }
 
       yield this.changeset.save();

--- a/app/pods/admin/deli-items/components/deli-item-form/template.hbs
+++ b/app/pods/admin/deli-items/components/deli-item-form/template.hbs
@@ -53,17 +53,7 @@
         </button>
       {{/if}}
 
-      {{#if this.fileErrorMessage}}
-        <span class="block mt-2 text-red-500">
-          This is an error message.
-          {{this.fileErrorMessage}}
-        </span>
-      {{/if}}
-
-      <small
-        class="block mt-3 text-gray-700
-          {{if this.fileErrorMessage '' 'sm:inline-block sm:mt-0 sm:ml-2'}}"
-      >
+      <small class="block mt-3 text-gray-700 sm:inline-block sm:mt-0 sm:ml-2">
         Only JPG, JPEG, PNG, and GIF files are allowed.
       </small>
       <small class="block mt-3 text-gray-700">
@@ -77,6 +67,13 @@
           this site
         </a>.
       </small>
+
+      {{#if this.fileErrorMessage}}
+        <span class="block mt-2 text-red-500">
+          This is an error message.
+          {{this.fileErrorMessage}}
+        </span>
+      {{/if}}
 
       {{#if this.hasImage}}
         <div class="mt-4">

--- a/app/pods/admin/menu/components/menu-form/component.js
+++ b/app/pods/admin/menu/components/menu-form/component.js
@@ -7,6 +7,7 @@ import lookupValidator from 'ember-changeset-validations';
 import MenuValidations from 'butchers-market/validations/menu';
 import { dropTask, enqueueTask } from 'ember-concurrency';
 import baseUrl from 'butchers-market/utils/base-url';
+import { generatePdfFileName } from 'butchers-market/utils/file-name';
 
 export default class MenuFormComponent extends Component {
   @service router;
@@ -74,10 +75,12 @@ export default class MenuFormComponent extends Component {
 
     try {
       if (this.changeset.file) {
-        let response = yield this.changeset.file.upload(`${baseUrl}/upload/pdf`, {
+        const generatedFileName = generatePdfFileName(this.changeset.file);
+        yield this.changeset.file.upload(`${baseUrl}/upload`, {
           headers: this.uploadHeaders,
+          data: { generatedFileName },
         });
-        this.changeset.set('fileUrl', response.body);
+        this.changeset.set('fileUrl', generatedFileName);
       }
 
       yield this.changeset.save();

--- a/app/pods/admin/menu/components/menu-form/template.hbs
+++ b/app/pods/admin/menu/components/menu-form/template.hbs
@@ -31,18 +31,15 @@
         </label>
       {{/let}}
 
+      <small class="block mt-3 text-gray-700 sm:inline-block sm:mt-0 sm:ml-2">
+        Only PDF are allowed.
+      </small>
+
       {{#if this.fileErrorMessage}}
         <span class="block mt-2 text-red-500">
           {{this.fileErrorMessage}}
         </span>
       {{/if}}
-
-      <small
-        class="block mt-3 text-gray-700
-          {{if this.fileErrorMessage '' 'sm:inline-block sm:mt-0 sm:ml-2'}}"
-      >
-        Only PDF are allowed.
-      </small>
 
       {{#if this.hasFile}}
         <div class="mt-4">

--- a/app/pods/admin/package-bundles/components/delete-package-bundle-form/template.hbs
+++ b/app/pods/admin/package-bundles/components/delete-package-bundle-form/template.hbs
@@ -19,11 +19,6 @@
         <Group.readonly @value={{@bundle.title}} />
       </Form.group>
 
-      <Form.group data-test-id="flyer-download-link" as |Group|>
-        <Group.label>Flyer Download Link</Group.label>
-        <Group.readonly @value={{@bundle.flyerDownloadLink}} />
-      </Form.group>
-
       <Form.group data-test-id="prices" as |Group|>
         <Group.label>Prices</Group.label>
         <ul class="list-disc list-inside">

--- a/app/pods/admin/package-bundles/components/package-bundle-form/template.hbs
+++ b/app/pods/admin/package-bundles/components/package-bundle-form/template.hbs
@@ -19,17 +19,57 @@
     <Group.textbox @value={{this.changeset.title}} @onChange={{set this "changeset.title"}} />
   </Form.group>
 
-  <Form.group
-    data-test-id="flyer-download-link"
-    @model={{this.changeset}}
-    @property="flyerDownloadLink"
-    as |Group|
-  >
-    <Group.label>Flyer Download Link</Group.label>
-    <Group.textbox
-      @value={{this.changeset.flyerDownloadLink}}
-      @onChange={{set this "changeset.flyerDownloadLink"}}
-    />
+  <Form.group data-test-id="file" @model={{this.changeset}} @property="fileUrl" as |Group|>
+    <Group.label>PDF File <Admin::Components::Required /></Group.label>
+    <div class="mt-2">
+      {{#let (file-queue name="file" onFileAdded=this.uploadFile) as |queue|}}
+        <label for={{Group.uniqueId}}>
+          <span
+            class="inline-block px-4 py-2 text-sm border cursor-pointer hover:bg-gray-200 focus:outline-none focus:ring"
+          >
+            Select PDF
+          </span>
+          <input
+            type="file"
+            id={{Group.uniqueId}}
+            accept="application/pdf"
+            hidden
+            {{queue.selectFile}}
+          />
+        </label>
+      {{/let}}
+
+      {{#if this.hasFile}}
+        <button
+          type="button"
+          class="inline-block ml-2 px-4 py-2 text-sm border cursor-pointer hover:bg-gray-200 focus:outline-none focus:ring"
+          {{on "click" this.removeFile}}
+        >
+          Remove PDF
+        </button>
+      {{/if}}
+
+      <small class="block mt-3 text-gray-700 sm:inline-block sm:mt-0 sm:ml-2">
+        Only PDF are allowed.
+      </small>
+
+      {{#if this.fileErrorMessage}}
+        <span class="block mt-2 text-red-500">
+          {{this.fileErrorMessage}}
+        </span>
+      {{/if}}
+
+      {{#if this.hasFile}}
+        <div class="mt-4">
+          <iframe
+            src={{this.fileUrl}}
+            title="Package Bundle PDF"
+            height="600px"
+            class="w-full"
+          ></iframe>
+        </div>
+      {{/if}}
+    </div>
   </Form.group>
 
   <Form.group data-test-id="prices">

--- a/app/pods/admin/specials/components/special-form/component.js
+++ b/app/pods/admin/specials/components/special-form/component.js
@@ -8,6 +8,7 @@ import SpecialValidations from 'butchers-market/validations/special';
 import { dropTask, enqueueTask } from 'ember-concurrency';
 import baseUrl from 'butchers-market/utils/base-url';
 import config from 'butchers-market/config/environment';
+import { generateFileName } from 'butchers-market/utils/file-name';
 
 export default class SpecialFormComponent extends Component {
   @service router;
@@ -81,10 +82,12 @@ export default class SpecialFormComponent extends Component {
 
     try {
       if (this.changeset.image) {
-        let response = yield this.changeset.image.upload(`${baseUrl}/upload`, {
+        const generatedFileName = generateFileName(this.changeset.image);
+        yield this.changeset.image.upload(`${baseUrl}/upload`, {
           headers: this.uploadHeaders,
+          data: { generatedFileName },
         });
-        this.changeset.set('imageUrl', response.body);
+        this.changeset.set('imageUrl', generatedFileName);
       }
 
       yield this.changeset.save();

--- a/app/pods/admin/specials/components/special-form/template.hbs
+++ b/app/pods/admin/specials/components/special-form/template.hbs
@@ -93,7 +93,7 @@
 
       {{#if this.hasImage}}
         <div class="mt-4">
-          <img src={{this.imageUrl}} alt="Event" class="w-full block" />
+          <img src={{this.imageUrl}} alt="Special" class="w-full block" />
         </div>
       {{/if}}
     </div>

--- a/app/pods/admin/specials/components/special-form/template.hbs
+++ b/app/pods/admin/specials/components/special-form/template.hbs
@@ -67,16 +67,7 @@
         </button>
       {{/if}}
 
-      {{#if this.fileErrorMessage}}
-        <span class="block mt-2 text-red-500">
-          {{this.fileErrorMessage}}
-        </span>
-      {{/if}}
-
-      <small
-        class="block mt-3 text-gray-700
-          {{if this.fileErrorMessage '' 'sm:inline-block sm:mt-0 sm:ml-2'}}"
-      >
+      <small class="block mt-3 text-gray-700 sm:inline-block sm:mt-0 sm:ml-2">
         Only JPG, JPEG, PNG, and GIF files are allowed.
       </small>
       <small class="block mt-3 text-gray-700">
@@ -90,6 +81,12 @@
           this site
         </a>.
       </small>
+
+      {{#if this.fileErrorMessage}}
+        <span class="block mt-2 text-red-500">
+          {{this.fileErrorMessage}}
+        </span>
+      {{/if}}
 
       {{#if this.hasImage}}
         <div class="mt-4">

--- a/app/pods/meat/template.hbs
+++ b/app/pods/meat/template.hbs
@@ -66,9 +66,9 @@
     <HeaderTitle @title={{bundle.title}} />
 
     <Container>
-      {{#if bundle.flyerDownloadLink}}
+      {{#if bundle.fileUrlPath}}
         <div class="mt-8 text-center">
-          <Button @href={{bundle.flyerDownloadLink}}>
+          <Button @href={{bundle.fileUrlPath}}>
             Print Flyer
           </Button>
         </div>

--- a/app/utils/file-name.js
+++ b/app/utils/file-name.js
@@ -1,0 +1,31 @@
+import { v4 as uuidv4 } from 'uuid';
+import format from 'date-fns/format';
+
+/**
+ * Generates a file name to store in the database for general files.
+ *
+ * @param {*} file
+ * @return Returns the file name to store.
+ */
+export function generateFileName(file) {
+  const fileParts = file.name.split('.');
+  const extension = fileParts.length > 1 ? `.${fileParts[fileParts.length - 1]}` : '';
+  return `${uuidv4()}${extension}`;
+}
+
+/**
+ * Generates a file name to store in the database for PDF files.
+ *
+ * @param {*} file
+ * @return Returns the file name to store.
+ */
+export function generatePdfFileName(file) {
+  const fileParts = file.name.split('.');
+  const extension = fileParts.length > 1 ? `.${fileParts[fileParts.length - 1]}` : '';
+
+  // Remove the extension.
+  fileParts.splice(fileParts.length - 1, 1);
+
+  const dateStamp = format(new Date(), 'yyyyMMdd');
+  return `${fileParts.join('.')}_${dateStamp}${extension}`;
+}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -131,14 +131,7 @@ function routes() {
   this.post(
     '/upload',
     upload(function (db, request) {
-      return new Response(201, { 'Content-Type': 'text/plain' }, request.requestBody.file.url);
-    })
-  );
-
-  this.post(
-    '/upload/pdf',
-    upload(function (db, request) {
-      return new Response(201, { 'Content-Type': 'text/plain' }, request.requestBody.file.url);
+      return new Response(201, { 'Content-Type': 'text/plain' }, {});
     })
   );
 }

--- a/mirage/factories/package-bundle.js
+++ b/mirage/factories/package-bundle.js
@@ -7,7 +7,12 @@ export default Factory.extend({
     return faker.lorem.words(wordCount);
   },
 
+  // deprecated!
   flyerDownloadLink() {
+    return 'docs/bundles-mixnmatch.pdf';
+  },
+
+  fileUrl() {
     return 'docs/bundles-mixnmatch.pdf';
   },
 

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -246,6 +246,7 @@ function createPackageBundles(server) {
     title: "Mix N' Match",
     displayOrder: 1,
     flyerDownloadLink: 'docs/bundles-mixnmatch.pdf',
+    fileUrl: 'docs/bundles-mixnmatch.pdf',
     prices: ['Pick 5 for $53', 'Pick 10 for $99', 'Pick 20 for $195'],
     items: [
       '2 (7 oz.) Beef Ribeye Steaks',
@@ -279,6 +280,7 @@ function createPackageBundles(server) {
     title: "Ice Box Mix N' Match",
     displayOrder: 2,
     flyerDownloadLink: 'docs/iceboxflyer.pdf',
+    fileUrl: 'docs/iceboxflyer.pdf',
     prices: ['Pick 5 for $19.99', 'Pick 10 for $37.99', 'Pick 20 for $75.99'],
     items: [
       'Spicy Chicken Tenders',

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "qunit": "^2.19.1",
         "qunit-dom": "^2.0.0",
         "tailwindcss": "^3.1.7",
+        "uuid": "^8.3.2",
         "webpack": "^5.74.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "butchers-market",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "butchers-market",
-      "version": "1.9.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@ember/optional-features": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "butchers-market",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "private": true,
   "description": "Source code for The Butcher's Market website.",
   "repository": "https://github.com/stewartandrewmiller/butchers-market-v2",
@@ -98,7 +98,7 @@
     "edition": "octane"
   },
   "volta": {
-    "node": "16.16.0",
+    "node": "18.7.0",
     "npm": "8.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "qunit": "^2.19.1",
     "qunit-dom": "^2.0.0",
     "tailwindcss": "^3.1.7",
+    "uuid": "^8.3.2",
     "webpack": "^5.74.0"
   },
   "engines": {


### PR DESCRIPTION
This refactors how the file uploads were being done. Previously, when a file would be uploaded, the API would return the file name that it gave it. This is because the API was responsible for generating the file name. After upgrading `ember-file-upload` to newer versions, it seems that it broke being able to do that. To fix that, I moved the file name generation to the UI. Now, the UI will send the file name it generated to the API when it goes to save.

I also updated the meat package bundles so that you can now upload a PDF in the admin form.