### PR TITLE
Remove "flyer download link" from package bundles

### DIFF
--- a/app/models/package-bundle.js
+++ b/app/models/package-bundle.js
@@ -4,7 +4,6 @@ import config from 'butchers-market/config/environment';
 export default class PackageBundle extends Model {
   @attr('number') displayOrder;
   @attr('string') title;
-  @attr('string') flyerDownloadLink; // deprecated!
   @attr('string') fileUrl;
   @attr('string') specialText;
   @attr prices; // Array of strings

--- a/app/pods/admin/package-bundles/index/template.hbs
+++ b/app/pods/admin/package-bundles/index/template.hbs
@@ -12,7 +12,6 @@
 <Admin::Components::UiTable class="mt-8" as |Table|>
   <Table.head as |Thead|>
     <Thead.th>Title</Thead.th>
-    <Thead.th>Flyer Download Link</Thead.th>
     <Thead.th>Prices</Thead.th>
     <Thead.th>Special Text</Thead.th>
     <Thead.th>Items</Thead.th>
@@ -22,7 +21,6 @@
     {{#each this.sortedBundles as |bundle|}}
       <Tbody.tr as |Row|>
         <Row.td>{{bundle.title}}</Row.td>
-        <Row.td>{{bundle.flyerDownloadLink}}</Row.td>
         <Row.td>
           <ul>
             {{#each bundle.prices as |price|}}

--- a/mirage/factories/package-bundle.js
+++ b/mirage/factories/package-bundle.js
@@ -7,11 +7,6 @@ export default Factory.extend({
     return faker.lorem.words(wordCount);
   },
 
-  // deprecated!
-  flyerDownloadLink() {
-    return 'docs/bundles-mixnmatch.pdf';
-  },
-
   fileUrl() {
     return 'docs/bundles-mixnmatch.pdf';
   },

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -254,7 +254,6 @@ function createPackageBundles(server) {
   server.create('package-bundle', {
     title: "Mix N' Match",
     displayOrder: 1,
-    flyerDownloadLink: 'docs/bundles-mixnmatch.pdf',
     fileUrl: 'docs/bundles-mixnmatch.pdf',
     specialText: 'Pick 10 and 20 come with $10 gift card from now until Dec 31',
     prices: ['Pick 5 for $53', 'Pick 10 for $99', 'Pick 20 for $195'],
@@ -289,7 +288,6 @@ function createPackageBundles(server) {
   server.create('package-bundle', {
     title: "Ice Box Mix N' Match",
     displayOrder: 2,
-    flyerDownloadLink: 'docs/iceboxflyer.pdf',
     fileUrl: 'docs/iceboxflyer.pdf',
     specialText: null,
     prices: ['Pick 5 for $19.99', 'Pick 10 for $37.99', 'Pick 20 for $75.99'],


### PR DESCRIPTION
The flyer download link property and column for the Package Bundles was deprecated. Removing them from code so it doesn't cause confusion.