### PR TITLE
Update bundle pack PDF link

### DIFF
--- a/app/pods/meat/controller.js
+++ b/app/pods/meat/controller.js
@@ -5,4 +5,16 @@ export default class MeatController extends Controller {
   queryParams = ['packages'];
 
   @tracked packages = false;
+
+  get meatBundlePDF() {
+    const packageBundles = this.model.packageBundles;
+
+    // This is a really hacky way to get the same PDF that we use for the "Mix N' Match" section.
+    let mixnmatch = packageBundles.findBy('title', `Mix N' Match`);
+    if (mixnmatch) {
+      return mixnmatch.fileUrlPath;
+    }
+
+    return '';
+  }
 }

--- a/app/pods/meat/template.hbs
+++ b/app/pods/meat/template.hbs
@@ -51,11 +51,13 @@
   <HeaderTitle @title="Bundle Packs" />
 
   <Container>
-    <div class="mt-8 text-center">
-      <Button @href="docs/bundles-mixnmatch.pdf">
-        Print Flyer
-      </Button>
-    </div>
+    {{#if this.meatBundlePDF}}
+      <div class="mt-8 text-center">
+        <Button @href={{this.meatBundlePDF}}>
+          Print Flyer
+        </Button>
+      </div>
+    {{/if}}
 
     <ProductsList @products={{@model.bundles}} />
   </Container>


### PR DESCRIPTION
The "Bundle Pack" PDF link was hard coded when it should be using the same PDF as the "Mix N' Match" section. This is a hacky way to solve it and we should be doing something better in the future.