### PR TITLE
Use `master` branch for ember-test-selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "ember-source": "~5.8.0",
         "ember-template-imports": "^4.1.0",
         "ember-template-lint": "^5.13.0",
-        "ember-test-selectors": "^6.0.0",
+        "ember-test-selectors": "mainmatter/ember-test-selectors#master",
         "ember-truth-helpers": "^4.0.3",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
@@ -34781,8 +34781,7 @@
     },
     "node_modules/ember-test-selectors": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-6.0.0.tgz",
-      "integrity": "sha512-PgYcI9PeNvtKaF0QncxfbS68olMYM1idwuI8v/WxsjOGqUx5bmsu6V17vy/d9hX4mwmjgsBhEghrVasGSuaIgw==",
+      "resolved": "git+ssh://git@github.com/mainmatter/ember-test-selectors.git#83ad63779a50dd813d647ee1910f3f2111abf6a5",
       "dev": true,
       "dependencies": {
         "calculate-cache-key-for-tree": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "ember-source": "~5.8.0",
     "ember-template-imports": "^4.1.0",
     "ember-template-lint": "^5.13.0",
-    "ember-test-selectors": "^6.0.0",
+    "ember-test-selectors": "mainmatter/ember-test-selectors#master",
     "ember-truth-helpers": "^4.0.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
It seems that the most recent published version of `ember-test-selectors` doesn't support Babel version 8. Changing the dependency to pull from the `master` branch since it's been updated. We need to check back at some point to see if a new release gets published.

See: https://github.com/mainmatter/ember-test-selectors