### PR TITLE
Updates to "Grab and Go" page

### DIFF
--- a/app/components/grab-and-go-list.gts
+++ b/app/components/grab-and-go-list.gts
@@ -24,11 +24,21 @@ const GrabAndGoListComponent: TOC<GrabAndGoListSignature> = <template>
               Sold Out
             </div>
           {{/if}}
-          <img
-            class='w-full shadow-md object-cover sm:w-[264px] sm:h-[202px] md:w-[208px] md:h-[159px] lg:w-[212px] lg:h-[162px] xl:w-[276px] xl:h-[211px] 2xl:w-[340px] 2xl:h-[260px]'
-            src={{item.imageUrlPath}}
-            alt={{item.title}}
-          />
+
+          {{#let
+            'w-full shadow-md sm:w-[264px] sm:h-[202px] md:w-[208px] md:h-[159px] lg:w-[212px] lg:h-[162px] xl:w-[276px] xl:h-[211px] 2xl:w-[340px] 2xl:h-[260px]'
+            as |classes|
+          }}
+            {{#if item.imageUrlPath}}
+              <img class='object-cover {{classes}}' src={{item.imageUrlPath}} alt={{item.title}} />
+            {{else}}
+              <div
+                class='hidden sm:flex sm:items-center sm:justify-center sm:bg-gray-200 {{classes}}'
+              >
+                <span class='text-lg text-gray-700'>No Image</span>
+              </div>
+            {{/if}}
+          {{/let}}
         </div>
         <h4 class='mt-2 text-xl font-bold text-center text-gray-900'>{{item.title}}</h4>
         <p class='mt-1 text-center text-gray-600'>{{item.description}}</p>

--- a/app/components/main-nav/main-nav-items.gts
+++ b/app/components/main-nav/main-nav-items.gts
@@ -107,7 +107,7 @@ export default class MainNavItemsComponent extends Component<MainNavItemsSignatu
           href={{this.menuUrl}}
           class='block px-6 py-4 lg:flex lg:items-center lg:py-0 lg:h-full hover:text-red-600 text-center lg:text-left'
         >
-          Menu
+          Cafe Menu
         </a>
       </li>
       {{!-- Drew doesn't want the contact form anymore. Commenting this out instead of deleting in

--- a/app/templates/grab-and-go.hbs
+++ b/app/templates/grab-and-go.hbs
@@ -21,7 +21,9 @@
   <Container>
     <div class="mt-10 max-w-3xl mx-auto">
       <p class="text-center text-lg sm:text-2xl">
-        We constantly rotate our grab &amp; go items. Here are some of our most common items.
+        We constantly rotate our grab &amp; go items. Here are some of our other common items that
+        are
+        <span class="font-semibold">not currently available</span>.
       </p>
     </div>
 

--- a/app/templates/grab-and-go.hbs
+++ b/app/templates/grab-and-go.hbs
@@ -1,19 +1,7 @@
 <OrderBanner />
 
-<PromoSection @image="promo-grab.jpg" class="min-h-[400px]" as |Promo|>
-  <Container>
-    <div class="text-center lg:w-3/4 lg:text-left">
-      <Promo.title>
-        Grab &amp; Go
-      </Promo.title>
-      <Promo.subtitle>
-        Fresh items ready for you to grab and go.
-      </Promo.subtitle>
-    </div>
-  </Container>
-</PromoSection>
-
-<section>
+{{! We need 1px of padding so that the header margin takes over since we have no promo image. }}
+<section class="pt-px">
   <HeaderTitle @title="Today's Grab & Go Items" />
 
   <Container>


### PR DESCRIPTION
This updates the following on the "Grab and Go" page:

- Remove the promo section (that big image with the title)
- Add a filler for grab and go items with no image
- Update the subheader for common items

This also renames the “Menu” menu item to “Cafe Menu”