### PR TITLE
Remove featured from grab and go

### DIFF
--- a/app/components/admin/grab-and-go/delete-item-form.hbs
+++ b/app/components/admin/grab-and-go/delete-item-form.hbs
@@ -19,17 +19,15 @@
         <Group.readonly @value={{@special.title}} />
       </Form.group>
 
-      {{#if @special.activeStartDate}}
-        <Form.group data-test-id="start-date" as |Group|>
-          <Group.label>Active Start Date</Group.label>
-          <Group.readonly @value={{date-format @special.activeStartDate "LL/dd/yyyy"}} />
-        </Form.group>
+      <Form.group data-test-id="description" as |Group|>
+        <Group.label>Description</Group.label>
+        <Group.readonly @value={{@special.description}} />
+      </Form.group>
 
-        <Form.group data-test-id="end-date" as |Group|>
-          <Group.label>Active End Date</Group.label>
-          <Group.readonly @value={{date-format @special.activeEndDate "LL/dd/yyyy"}} />
-        </Form.group>
-      {{/if}}
+      <Form.group data-test-id="sold-out" as |Group|>
+        <Group.label>Is Sold Out?</Group.label>
+        <Group.readonly @value={{if @item.isSoldOut "Yes" "No"}} />
+      </Form.group>
     </Modal.body>
     <Modal.footer>
       <UiButton @variant="plain" @onClick={{@onCancel}}>

--- a/app/components/admin/grab-and-go/item-form.hbs
+++ b/app/components/admin/grab-and-go/item-form.hbs
@@ -71,21 +71,6 @@
     />
   </Form.group>
 
-  <Form.group data-test-id="hidden">
-    <label>
-      <input
-        type="checkbox"
-        checked={{this.changeset.featured}}
-        {{on "change" this.updateIsFeatured}}
-      />
-      <span class="ml-2">Is Featured?</span>
-    </label>
-    <small class="block mt-3 text-gray-700">
-      When checked, this means that it's available for purchase and is also featured on the home
-      page.
-    </small>
-  </Form.group>
-
   <Form.group data-test-id="sold-out">
     <label>
       <input

--- a/app/components/admin/grab-and-go/item-form.js
+++ b/app/components/admin/grab-and-go/item-form.js
@@ -113,11 +113,6 @@ export default class ItemFormComponent extends Component {
   }
 
   @action
-  updateIsFeatured() {
-    this.changeset.set('featured', !this.changeset.get('featured'));
-  }
-
-  @action
   updateIsSoldOut() {
     this.changeset.set('isSoldOut', !this.changeset.get('isSoldOut'));
   }

--- a/app/controllers/grab-and-go.js
+++ b/app/controllers/grab-and-go.js
@@ -4,11 +4,11 @@ import { format, formatISO } from 'date-fns';
 
 export default class GrabAndGoController extends Controller {
   get todaysItems() {
-    return this.model.filter((item) => item.featured);
+    return this.model.filter((item) => !item.isSoldOut);
   }
 
   get commonItems() {
-    return this.model.filter((item) => !item.featured);
+    return this.model.filter((item) => item.isSoldOut);
   }
 
   @cached

--- a/app/models/grab-and-go.ts
+++ b/app/models/grab-and-go.ts
@@ -5,7 +5,6 @@ export default class GrabAndGo extends Model {
   @attr() declare title: string;
   @attr() declare imageUrl: string;
   @attr() declare description: string;
-  @attr() declare featured: boolean;
   @attr() declare isSoldOut: boolean;
   @attr('date') declare createdAt: Date;
   @attr('date') declare updatedAt: Date;

--- a/app/templates/admin/grab-and-go/index.hbs
+++ b/app/templates/admin/grab-and-go/index.hbs
@@ -11,8 +11,6 @@
 <Admin::UiTable class="mt-8" as |Table|>
   <Table.head as |Thead|>
     <Thead.th>Title</Thead.th>
-    <Thead.th>Description</Thead.th>
-    <Thead.th>Is Featured?</Thead.th>
     <Thead.th>Sold Out?</Thead.th>
     <Thead.th />
   </Table.head>
@@ -21,12 +19,6 @@
       <Tbody.tr as |Row|>
         <Row.td>
           {{item.title}}
-        </Row.td>
-        <Row.td>
-          {{item.description}}
-        </Row.td>
-        <Row.td>
-          {{if item.featured "Yes" "No"}}
         </Row.td>
         <Row.td>
           {{if item.isSoldOut "Yes" "No"}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -74,10 +74,7 @@ function routes() {
   });
 
   this.resource('feature-flags');
-
-  // TODO: Need to add filters for this
   this.resource('grab-and-go');
-
   this.resource('hours');
 
   this.resource('meat-bundles', { only: ['show', 'update'] });

--- a/mirage/factories/grab-and-go.js
+++ b/mirage/factories/grab-and-go.js
@@ -10,9 +10,6 @@ export default Factory.extend({
   description() {
     return faker.lorem.sentence();
   },
-  isFeatured() {
-    faker.datatype.boolean({ probability: 0.6 });
-  },
   isSoldOut() {
     return faker.datatype.boolean({ probability: 0.1 });
   },

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -65,28 +65,30 @@ function createGrabAndGo(server) {
   server.create('grab-and-go', {
     title: 'Original meatloaf ',
     imageUrl: 'images/thanksgivingbreast.jpg',
-    featured: true,
     isSoldOut: false,
   });
 
   server.create('grab-and-go', {
     title: 'Smoked Queso',
     imageUrl: 'images/thanksgivingbreast.jpg',
-    featured: false,
     isSoldOut: true,
   });
 
   server.create('grab-and-go', {
     title: 'Mexican chicken casserole',
     imageUrl: 'images/thanksgivingbreast.jpg',
-    featured: true,
     isSoldOut: false,
   });
 
   server.create('grab-and-go', {
     title: 'Brisket Philly cheese pie',
     imageUrl: 'images/thanksgivingbreast.jpg',
-    featured: true,
+    isSoldOut: true,
+  });
+
+  server.create('grab-and-go', {
+    title: 'Chicken Casserole',
+    imageUrl: 'images/thanksgivingbreast.jpg',
     isSoldOut: false,
   });
 }


### PR DESCRIPTION
There's no reason to have a separate `featured` and `isSoldOut` on the Grab and Go items. Removing `featured` and if it's not `isSoldOut`, then it shows on "Today's Items". If it is, then it shows under "Common Items" and shows the "Sold Out" banner.

This also removes the "Description" column from the grid.