### PR TITLE
Fix table component for re-ordering

### DIFF
--- a/app/components/admin/ui-table.gts
+++ b/app/components/admin/ui-table.gts
@@ -139,7 +139,7 @@ interface UiTableBodySignature {
 }
 
 const UiTableBody: TOC<UiTableBodySignature> = <template>
-  <tbody class='divide-y divide-gray-200 bg-white'>
+  <tbody class='divide-y divide-gray-200 bg-white' ...attributes>
     {{yield (hash Empty=(component UiTableEmpty) Tr=UiTableRow)}}
   </tbody>
 </template>;


### PR DESCRIPTION
When I refactored the admin table component, I didn't add the splattributes to the `tbody`, which made re-ordering of items not work.