### PR TITLE
Add holiday grab and go item

### DIFF
--- a/app/components/admin/grab-and-go/item-form.hbs
+++ b/app/components/admin/grab-and-go/item-form.hbs
@@ -89,6 +89,12 @@
     </Group.checkbox>
   </Form.group>
 
+  <Form.group data-test-id="is-holiday" @model={{this.changeset}} @property="isHoliday" as |Group|>
+    <Group.checkbox @checked={{this.changeset.isHoliday}} @onChange={{this.updateIsHoliday}}>
+      Is Holiday?
+    </Group.checkbox>
+  </Form.group>
+
   <div class="mt-8">
     {{#if this.hasErrors}}
       <div class="mb-2 text-red-600">

--- a/app/components/admin/grab-and-go/item-form.js
+++ b/app/components/admin/grab-and-go/item-form.js
@@ -116,4 +116,9 @@ export default class ItemFormComponent extends Component {
   updateInStock() {
     this.changeset.set('inStock', !this.changeset.get('inStock'));
   }
+
+  @action
+  updateIsHoliday() {
+    this.changeset.set('isHoliday', !this.changeset.get('isHoliday'));
+  }
 }

--- a/app/components/admin/grab-and-go/mini-form.gts
+++ b/app/components/admin/grab-and-go/mini-form.gts
@@ -9,30 +9,51 @@ interface MiniFormSignature {
   Element: HTMLLIElement;
   Args: {
     item: GrabAndGo;
+    field: 'inStock' | 'isHoliday';
   };
   Blocks: EmptyObject;
 }
 
 export default class MiniFormComponent extends Component<MiniFormSignature> {
+  get isHoliday() {
+    return this.args.field === 'isHoliday';
+  }
+
+  get isChecked() {
+    const { item } = this.args;
+    return this.isHoliday ? item.isHoliday : item.inStock;
+  }
+
   saveItem = dropTask(async () => {
     await this.args.item.save();
   });
 
   @action
   handleOnChange(checked: boolean) {
-    this.args.item.inStock = checked;
+    const { item } = this.args;
+
+    if (this.isHoliday) {
+      item.isHoliday = checked;
+    } else {
+      item.inStock = checked;
+    }
+
     this.saveItem.perform();
   }
 
   <template>
     <AdminForm as |Form|>
-      <Form.group data-test-id='in-stock' @useDefaultMargin={{false}} as |Group|>
+      <Form.group
+        data-test-id={{if this.isHoliday 'is-holiday' 'in-stock'}}
+        @useDefaultMargin={{false}}
+        as |Group|
+      >
         <Group.checkbox
           @hideLabel={{true}}
-          @checked={{@item.inStock}}
+          @checked={{this.isChecked}}
           @onChange={{this.handleOnChange}}
         >
-          In Stock?
+          {{if this.isHoliday 'Is Holiday?' 'In Stock?'}}
         </Group.checkbox>
       </Form.group>
     </AdminForm>

--- a/app/controllers/grab-and-go.js
+++ b/app/controllers/grab-and-go.js
@@ -5,10 +5,7 @@ import { format, formatISO } from 'date-fns';
 export default class GrabAndGoController extends Controller {
   @cached
   get lastUpdatedOn() {
-    // We want to sort all items, not just today's items, because if an item was removed from
-    // today's items, we want that time to show as the last updated time.
-    const sortedItems = this.model
-      .slice()
+    const sortedItems = [...this.model.regularItems, ...this.model.holidayItems]
       .sort((a, b) => {
         return a.updatedAt - b.updatedAt;
       })

--- a/app/mirage/factories/grab-and-go.js
+++ b/app/mirage/factories/grab-and-go.js
@@ -16,6 +16,9 @@ export default Factory.extend({
   inStock() {
     return faker.datatype.boolean({ probability: 0.9 });
   },
+  isHoliday() {
+    return faker.datatype.boolean({ probability: 0.2 });
+  },
   createdAt() {
     return faker.date.recent(30);
   },

--- a/app/mirage/scenarios/default.js
+++ b/app/mirage/scenarios/default.js
@@ -67,6 +67,7 @@ function createGrabAndGo(server) {
     socialTitle: 'Original meatloaf 🥩',
     imageUrl: 'images/thanksgivingbreast.jpg',
     inStock: true,
+    isHoliday: false,
   });
 
   server.create('grab-and-go', {
@@ -74,6 +75,7 @@ function createGrabAndGo(server) {
     socialTitle: 'Smoked Queso',
     imageUrl: 'images/thanksgivingbreast.jpg',
     inStock: false,
+    isHoliday: false,
   });
 
   server.create('grab-and-go', {
@@ -81,6 +83,7 @@ function createGrabAndGo(server) {
     socialTitle: 'Mexican chicken casserole',
     imageUrl: 'images/thanksgivingbreast.jpg',
     inStock: true,
+    isHoliday: false,
   });
 
   server.create('grab-and-go', {
@@ -88,6 +91,7 @@ function createGrabAndGo(server) {
     socialTitle: 'Brisket Philly cheese pie',
     imageUrl: 'images/thanksgivingbreast.jpg',
     inStock: false,
+    isHoliday: false,
   });
 
   server.create('grab-and-go', {
@@ -95,6 +99,23 @@ function createGrabAndGo(server) {
     socialTitle: 'Chicken Casserole',
     imageUrl: 'images/thanksgivingbreast.jpg',
     inStock: true,
+    isHoliday: false,
+  });
+
+  server.create('grab-and-go', {
+    title: 'Turkey',
+    socialTitle: null,
+    imageUrl: 'images/thanksgivingbreast.jpg',
+    inStock: true,
+    isHoliday: true,
+  });
+
+  server.create('grab-and-go', {
+    title: 'Ham',
+    socialTitle: null,
+    imageUrl: 'images/thanksgivingbreast.jpg',
+    inStock: true,
+    isHoliday: true,
   });
 }
 

--- a/app/mirage/servers/default.js
+++ b/app/mirage/servers/default.js
@@ -47,7 +47,24 @@ function routes() {
   });
 
   this.resource('feature-flags');
+
   this.resource('grab-and-go');
+  this.get('/grab-and-gos', ({ grabAndGos }, request) => {
+    const isHoliday = request.queryParams['filter[isHoliday]'];
+    const inStock = request.queryParams['filter[inStock]'];
+    let whereStatement = {};
+
+    if (isHoliday !== undefined) {
+      whereStatement.isHoliday = isHoliday === 'true';
+    }
+
+    if (inStock !== undefined) {
+      whereStatement.inStock = inStock === 'true';
+    }
+
+    return grabAndGos.where(whereStatement);
+  });
+
   this.resource('hours');
 
   this.resource('meat-bundles', { only: ['show', 'update'] });

--- a/app/models/grab-and-go.ts
+++ b/app/models/grab-and-go.ts
@@ -12,6 +12,7 @@ export default class GrabAndGo extends Model {
     },
   })
   declare inStock: boolean;
+  @attr() declare isHoliday: boolean;
   @attr('date') declare createdAt: Date;
   @attr('date') declare updatedAt: Date;
 

--- a/app/routes/grab-and-go.js
+++ b/app/routes/grab-and-go.js
@@ -5,8 +5,16 @@ import { service } from '@ember/service';
 export default class GrabAndGoRoute extends Route {
   @service store;
 
-  model() {
-    return this.store.query('grab-and-go', { filter: { inStock: true } });
+  async model() {
+    const holidayItems = this.store.query('grab-and-go', {
+      filter: { inStock: true, isHoliday: true },
+    });
+    const regularItems = this.store.query('grab-and-go', {
+      filter: { inStock: true, isHoliday: false },
+    });
+
+    const [holiday, regular] = await Promise.all([holidayItems, regularItems]);
+    return { holidayItems: holiday, regularItems: regular };
   }
 
   @action

--- a/app/templates/admin/grab-and-go/index.hbs
+++ b/app/templates/admin/grab-and-go/index.hbs
@@ -19,6 +19,7 @@
   <Table.Head as |Thead|>
     <Thead.Th>Title</Thead.Th>
     <Thead.Th>In Stock?</Thead.Th>
+    <Thead.Th>Is Holiday?</Thead.Th>
     <Thead.Th />
   </Table.Head>
   <Table.Body as |Tbody|>
@@ -28,7 +29,10 @@
           {{item.title}}
         </Row.Td>
         <Row.Td>
-          <Admin::GrabAndGo::MiniForm @item={{item}} />
+          <Admin::GrabAndGo::MiniForm @item={{item}} @fild="inStock" />
+        </Row.Td>
+        <Row.Td>
+          <Admin::GrabAndGo::MiniForm @item={{item}} @field="isHoliday" />
         </Row.Td>
         <Row.Td>
           <div class="flex justify-end">

--- a/app/templates/grab-and-go.hbs
+++ b/app/templates/grab-and-go.hbs
@@ -1,7 +1,19 @@
 <MobileOrderBanner />
 
 {{! We need 1px of padding so that the header margin takes over since we have no promo image. }}
-<section class="pt-px">
+<div class="pt-px"></div>
+
+{{#if this.model.holidayItems.length}}
+  <section>
+    <HeaderTitle @title="Holiday Grab & Go Items" />
+
+    <Container>
+      <GrabAndGoList @items={{this.model.holidayItems}} />
+    </Container>
+  </section>
+{{/if}}
+
+<section>
   <HeaderTitle @title="Today's Grab & Go Items" />
 
   <Container>
@@ -15,6 +27,6 @@
       </p>
     </div>
 
-    <GrabAndGoList @items={{this.model}} />
+    <GrabAndGoList @items={{this.model.regularItems}} />
   </Container>
 </section>


### PR DESCRIPTION
This adds a new "is holiday" option to the Grab and Go items so that if marked as "is holiday", it will be grouped in a new section at the top of the Grab and Go page. If there are no items marked as "is holiday", then the section won't appear.